### PR TITLE
Fixed major bugs in boundary_*.f90

### DIFF
--- a/common/boundary_periodic.f90
+++ b/common/boundary_periodic.f90
@@ -134,7 +134,7 @@ contains
        cnt2(nys:nye) = 0
 !$OMP END WORKSHARE
 
-!$OMP DO PRIVATE(ii,j,jpos)
+!$OMP DO PRIVATE(ii,j,idim,jpos)
        do j=nys,nye
           do ii=1,np2(j,isp)
 

--- a/proj/shock/boundary_shock.f90
+++ b/proj/shock/boundary_shock.f90
@@ -142,7 +142,7 @@ contains
        cnt2(nys:nye) = 0
 !$OMP END WORKSHARE
 
-!$OMP DO PRIVATE(ii,j,jpos)
+!$OMP DO PRIVATE(ii,j,idim,jpos)
        do j=nys,nye
           do ii=1,np2(j,isp)
 


### PR DESCRIPTION
Fixed bugs in boundary_*.f90. `idim` is now a private variable of OpenMP thread.