### PR TITLE
Fix of MPI-IO issues on Fugaku

### DIFF
--- a/common/paraio.f90
+++ b/common/paraio.f90
@@ -68,7 +68,7 @@ contains
     ! allocate MPI buffer
     psize = ndim*np*(nye-nys+5)*nsp
     fsize = 6*(nxge-nxgs+5)*(nye-nys+5)
-    isize = (nye-nys+1)*nsp;
+    isize = (nye-nys+1)*nsp
     allocate(mpibuf1(max(psize, fsize)))
     allocate(mpibuf2(isize))
 

--- a/utils/iocore/jsonio.f90
+++ b/utils/iocore/jsonio.f90
@@ -403,6 +403,8 @@ contains
     character(len=128) :: dataname
     integer :: i
 
+    dshape = 0
+
     call json%get(src, name // '.offset', disp)
     call jsonio_check_error(json, 'get_metadata')
 

--- a/utils/iocore/mpiio.f90
+++ b/utils/iocore/mpiio.f90
@@ -762,12 +762,15 @@ contains
     integer, intent(in)               :: file
     integer(MOK), intent(inout)       :: disp
     integer(4), target, intent(inout) :: data(:)
-
+#if 0
     integer, pointer :: dummy(:)
 
     dummy => data
     call read_atomic_array_type(file, disp, dummy(1), 4*size(data))
-
+#else
+    call MPI_File_read_at(file, disp, data, 4*size(data), MPI_BYTE, mpistat, mpierr)
+    disp = disp + 4*size(data)
+#endif
   end subroutine read_atomic_array_i4
 
   !
@@ -778,14 +781,17 @@ contains
     integer, intent(in)            :: file
     integer(MOK), intent(inout)    :: disp
     integer(8), target, intent(in) :: data(:)
-
+#if 0
     integer, pointer :: dummy(:)
     integer, target  :: dummy_data(1)
 
     dummy_data = transfer(data, dummy_data)
     dummy => dummy_data
     call read_atomic_array_type(file, disp, dummy(1), 8*size(data))
-
+#else
+    call MPI_File_read_at(file, disp, data, 8*size(data), MPI_BYTE, mpistat, mpierr)
+    disp = disp + 8*size(data)
+#endif
   end subroutine read_atomic_array_i8
 
   !
@@ -796,13 +802,17 @@ contains
     integer, intent(in)            :: file
     integer(MOK), intent(inout)    :: disp
     real(4), target, intent(in)    :: data(:)
-
+#if 0
     integer, pointer :: dummy(:)
     integer, target  :: dummy_data(1)
 
     dummy_data = transfer(data, dummy_data)
     dummy => dummy_data
     call read_atomic_array_type(file, disp, dummy(1), 4*size(data))
+#else
+    call MPI_File_read_at(file, disp, data, 4*size(data), MPI_BYTE, mpistat, mpierr)
+    disp = disp + 4*size(data)
+#endif
 
   end subroutine read_atomic_array_r4
 
@@ -814,13 +824,17 @@ contains
     integer, intent(in)            :: file
     integer(MOK), intent(inout)    :: disp
     real(8), target, intent(in)    :: data(:)
-
+#if 0
     integer, pointer :: dummy(:)
     integer, target  :: dummy_data(1)
 
     dummy_data = transfer(data, dummy_data)
     dummy => dummy_data
     call read_atomic_array_type(file, disp, dummy(1), 8*size(data))
+#else
+    call MPI_File_read_at(file, disp, data, 8*size(data), MPI_BYTE, mpistat, mpierr)
+    disp = disp + 8*size(data)
+#endif
 
   end subroutine read_atomic_array_r8
 


### PR DESCRIPTION
This PR will fix MPI-IO issues on Fugaku.
Confirmed to work with lang/tcsds-1.2.34 for both starting from the initial condition and restarting from an intermediate state for the default setup of Weibel instability.
Yet need testing on the other systems.